### PR TITLE
root/language/en/mods/dkp_common.php Missing Value

### DIFF
--- a/root/language/en/mods/dkp_common.php
+++ b/root/language/en/mods/dkp_common.php
@@ -294,6 +294,7 @@ $lang = array_merge($lang, array(
 'TIME' => 'Time',
 'TIME_BONUS' => 'Time bonus',
 'TOTAL' => 'Total',
+'TIMEVALUE' => 'Time Value',
 'TOTAL_EARNED' => 'Total Earned',
 'TOTAL_ITEMS' => 'Total Items',
 'TOTAL_RAIDS' => 'Total Raids',


### PR DESCRIPTION
missing value when using the BBDKP admin tab -->List Raids-->Edit Raid-->Edit Member  You will notice it shows {TIMEVALUE} instead of Time Value
