### PR TITLE
Fixed member name sorting in the Attendance section.  Do not use member_...

### DIFF
--- a/root/includes/bbdkp/module/stats.php
+++ b/root/includes/bbdkp/module/stats.php
@@ -556,7 +556,7 @@ class statistics
 				1 => array ("sum(CASE e.days WHEN '".$config['bbdkp_list_p3']."' THEN e.attendance END ) desc", "sum(CASE e.days WHEN '".$config['bbdkp_list_p3']."' THEN e.attendance END ) asc" ),
 				2 => array ("sum(CASE e.days WHEN '".$config['bbdkp_list_p2']."' THEN e.attendance END ) desc", "sum(CASE e.days WHEN '".$config['bbdkp_list_p2']."' THEN e.attendance END ) asc" ),
 				3 => array ("sum(CASE e.days WHEN '".$config['bbdkp_list_p1']."' THEN e.attendance END ) desc", "sum(CASE e.days WHEN '".$config['bbdkp_list_p1']."' THEN e.attendance END ) asc" ),
-				4 => array ("e.member_id desc", "e.member_id asc" ),		
+				4 => array ("e.member_name asc", "e.member_name desc" ),	
 			);
 			
 		$att_current_order = switch_order ( $att_sort_order );		


### PR DESCRIPTION
...id as your sort value, instead use member_name.
