### PR TITLE
Net Current DKP is not taking into account Total Decay in its figures. (...

### DIFF
--- a/root/includes/bbdkp/module/viewmember.php
+++ b/root/includes/bbdkp/module/viewmember.php
@@ -253,8 +253,8 @@ $template->assign_vars(array(
 	'C_TOTAL_DECAY'	=> ($member['member_raid_decay'] -$member['member_item_decay'] + $member['adj_decay']) > 0 ? 'negative' : 'positive' ,
 
 
-	'NETCURRENT'    => $member['ep_net'] - $member['gp_net'] - max(0, $config['bbdkp_basegp']) ,
-	'C_NETCURRENT'      => (($member['member_current'] + $member['member_item_decay'] - max(0, $config['bbdkp_basegp']) ) > 0   )  ? 'positive' : 'negative',
+	'NETCURRENT'    => $member['ep_net'] - $member['gp_net'] - max(0, $config['bbdkp_basegp']) - ( $member['member_raid_decay'] - $member['member_item_decay'] + $member['adj_decay']) ,
+	'C_NETCURRENT'      => (($member['member_current'] + $member['member_item_decay'] - max(0, $config['bbdkp_basegp']) - ( $member['member_raid_decay'] - $member['member_item_decay'] + $member['adj_decay'])) > 0   )  ? 'positive' : 'negative',
 	
 	'MEMBER_LEVEL'    => $member['member_level'],
 	'MEMBER_DKPID'    => $dkp_id,


### PR DESCRIPTION
...I believe it should, shouldn't it?)  If you enable Decay in the Admin panel, the Statistics Page is the only place that shows  the correct DKP which takes into account the Total Decay.  Also Standings does not take into account Decay as well. I will work on that next, once I get confirmation that this is indeed a problem.
