### PR TITLE
Support for guilds with multiple characters of the same name in the same...

### DIFF
--- a/root/includes/ucp/ucp_dkp.php
+++ b/root/includes/ucp/ucp_dkp.php
@@ -133,7 +133,7 @@ class ucp_dkp extends \bbdkp\admin\Admin
                     {
                         foreach ($member->guildmemberlist as $id => $m  )
                         {
-                            $s_guildmembers .= '<option value="' . $m['member_id'] .'">'. $m['rank_name']  . ' ' . $m['member_name'] . '</option>';
+                            $s_guildmembers .= '<option value="' . $m['member_id'] .'">'. $m['rank_name']  . ' ' . $m['member_name'] . '-' . $m['member_realm'] '</option>';
                         }
                     }
                     else

--- a/root/install/index.php
+++ b/root/install/index.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * bbDKP Umil Installer
  *
@@ -261,7 +261,7 @@ $versions = array(
 
                 ),
                 'PRIMARY_KEY'  => 'member_id',
-                'KEYS'         => array('member_name'    => array('UNIQUE', 'member_name')),
+                'KEYS'         => array('member_name_member_realm'    => array('UNIQUE', 'member_name', 'member_realm')),
             ),
             ),
 


### PR DESCRIPTION
... guild but on different realms.

Wow now supports having multiple characters with the same name but on
different realms on joint realms.  This update adds realms to being used
as a filter criteria for identifying character uniqueness.  It updates a
unique key in the DB and also updates the character claim screen to list
out realms in the options.

This does need some further testing as it is a dump from my fairly highly modified version that supports some other features like TS integration and pushing updates to forum group memberships (along with confirming character claims).  I've stripped that functionality out, but that means that I don't have a solid test yet.
